### PR TITLE
If defined, use ECCODES_DIR environment variable to find libeccodes.so

### DIFF
--- a/cfgrib/bindings.py
+++ b/cfgrib/bindings.py
@@ -17,6 +17,7 @@
 #   Alessandro Amici - B-Open - https://bopen.eu
 #
 
+import os
 import functools
 import logging
 import pkgutil

--- a/cfgrib/bindings.py
+++ b/cfgrib/bindings.py
@@ -42,6 +42,11 @@ try:
 except Exception:
     pass
 
+if os.environ.get("ECCODES_DIR"):
+    eccdir = os.environ["ECCODES_DIR"]
+    LIBNAMES.insert(0, os.path.join(eccdir, "lib/libeccodes.so"))
+    LIBNAMES.insert(0, os.path.join(eccdir, "lib64/libeccodes.so"))
+
 for libname in LIBNAMES:
     try:
         lib = ffi.dlopen(libname)


### PR DESCRIPTION
Backported from ecCodes' own bindings the option to use ECCODES_DIR environment variable to locate the library to dlopen. 