### PR TITLE
Add support for reading extra coordinates

### DIFF
--- a/cfgrib/dataset.py
+++ b/cfgrib/dataset.py
@@ -536,7 +536,12 @@ def build_variable_components(
                         header_value, coord_value
                     )
                     if saved_coord_value != coord_value:
-                        raise DatasetBuildError("pippo")
+                        raise ValueError(
+                            f"'{coord_name}' cannot be indexed by dimension '{extra_coords[coord_name]}': \n"
+                            f"found two '{coord_name}' distinct values ({saved_coord_value}, {coord_value}) "
+                            f"for '{extra_coords[coord_name]}' value {header_value}."
+                        )
+
                     extra_coords_data[coord_name][header_value] = coord_value
         offsets[tuple(header_indexes)] = offset
     missing_value = data_var_attrs.get("missingValue", 9999)
@@ -697,7 +702,7 @@ def open_file(
     read_keys: T.Sequence[str] = (),
     time_dims: T.Sequence[str] = ("time", "step"),
     extra_coords: T.Dict[str, str] = {},
-    **kwargs: T.Any
+    **kwargs: T.Any,
 ) -> Dataset:
     """Open a GRIB file as a ``cfgrib.Dataset``."""
     index_keys = INDEX_KEYS + list(filter_by_keys) + list(time_dims) + list(extra_coords.keys())

--- a/cfgrib/dataset.py
+++ b/cfgrib/dataset.py
@@ -470,6 +470,7 @@ def build_variable_components(
     squeeze: bool = True,
     read_keys: T.Iterable[str] = (),
     time_dims: T.Sequence[str] = ("time", "step"),
+    extra_coords: T.Dict[str, str] = {},
 ) -> T.Tuple[T.Dict[str, int], Variable, T.Dict[str, Variable]]:
     data_var_attrs = enforce_unique_attributes(index, DATA_ATTRIBUTES_KEYS, filter_by_keys)
     grid_type_keys = GRID_TYPE_MAP.get(index.getone("gridType"), [])
@@ -516,6 +517,9 @@ def build_variable_components(
 
     offsets = {}  # type: T.Dict[T.Tuple[int, ...], T.List[T.Union[int, T.Tuple[int, int]]]]
     header_value_index = {}
+    extra_coords_data: T.Dict[str, T.Dict[str, T.Any]] = {
+        coord_name: {} for coord_name in extra_coords
+    }
     for dim in header_dimensions:
         header_value_index[dim] = {v: i for i, v in enumerate(coord_vars[dim].data.tolist())}
     for header_values, offset in index.offsets:
@@ -523,6 +527,17 @@ def build_variable_components(
         for dim in header_dimensions:
             header_value = header_values[index.index_keys.index(coord_name_key_map.get(dim, dim))]
             header_indexes.append(header_value_index[dim][header_value])
+            for coord_name in extra_coords:
+                coord_value = header_values[
+                    index.index_keys.index(coord_name_key_map.get(coord_name, coord_name))
+                ]
+                if dim == extra_coords[coord_name]:
+                    saved_coord_value = extra_coords_data[coord_name].get(
+                        header_value, coord_value
+                    )
+                    if saved_coord_value != coord_value:
+                        raise DatasetBuildError("pippo")
+                    extra_coords_data[coord_name][header_value] = coord_value
         offsets[tuple(header_indexes)] = offset
     missing_value = data_var_attrs.get("missingValue", 9999)
     data = OnDiskArray(
@@ -541,6 +556,11 @@ def build_variable_components(
         attrs = COORD_ATTRS["valid_time"]
         coord_vars["valid_time"] = Variable(dimensions=time_dims, data=time_data, attributes=attrs)
 
+    for coord_name in extra_coords:
+        coord_vars[coord_name] = Variable(
+            dimensions=(extra_coords[coord_name],),
+            data=np.array(list(extra_coords_data[coord_name].values())),
+        )
     data_var_attrs["coordinates"] = " ".join(coord_vars.keys())
     data_var = Variable(dimensions=dimensions, data=data, attributes=data_var_attrs)
     dims = {d: s for d, s in zip(dimensions, data_var.data.shape)}
@@ -589,6 +609,7 @@ def build_dataset_components(
     log: logging.Logger = LOG,
     read_keys: T.Iterable[str] = (),
     time_dims: T.Sequence[str] = ("time", "step"),
+    extra_coords: T.Dict[str, str] = {},
 ) -> T.Tuple[T.Dict[str, int], T.Dict[str, Variable], T.Dict[str, T.Any], T.Dict[str, T.Any]]:
     dimensions = {}  # type: T.Dict[str, int]
     variables = {}  # type: T.Dict[str, Variable]
@@ -604,6 +625,7 @@ def build_dataset_components(
                 squeeze=squeeze,
                 read_keys=read_keys,
                 time_dims=time_dims,
+                extra_coords=extra_coords,
             )
         except DatasetBuildError as ex:
             # NOTE: When a variable has more than one value for an attribute we need to raise all
@@ -674,11 +696,14 @@ def open_file(
     filter_by_keys: T.Dict[str, T.Any] = {},
     read_keys: T.Sequence[str] = (),
     time_dims: T.Sequence[str] = ("time", "step"),
+    extra_coords: T.Dict[str, str] = {},
     **kwargs: T.Any
 ) -> Dataset:
     """Open a GRIB file as a ``cfgrib.Dataset``."""
-    index_keys = INDEX_KEYS + list(filter_by_keys) + list(time_dims)
+    index_keys = INDEX_KEYS + list(filter_by_keys) + list(time_dims) + list(extra_coords.keys())
     index = open_fileindex(path, grib_errors, indexpath, index_keys, filter_by_keys=filter_by_keys)
     return Dataset(
-        *build_dataset_components(index, read_keys=read_keys, time_dims=time_dims, **kwargs)
+        *build_dataset_components(
+            index, read_keys=read_keys, time_dims=time_dims, extra_coords=extra_coords, **kwargs
+        )
     )

--- a/tests/test_30_dataset.py
+++ b/tests/test_30_dataset.py
@@ -206,6 +206,11 @@ def test_Dataset_extra_coords():
     assert res.variables["experimentVersionNumber"].dimensions == ("time",)
 
 
+def test_Dataet_extra_coords_error():
+    with pytest.raises(ValueError):
+        dataset.open_file(TEST_DATA, extra_coords={"validityDate": "number"})
+
+
 def test_OnDiskArray():
     res = dataset.open_file(TEST_DATA).variables["t"]
 

--- a/tests/test_30_dataset.py
+++ b/tests/test_30_dataset.py
@@ -200,6 +200,12 @@ def test_Dataset_reguler_gg_surface():
     assert np.allclose(res.variables["latitude"].data[:2], [88.57216851, 86.72253095])
 
 
+def test_Dataset_extra_coords():
+    res = dataset.open_file(TEST_DATA, extra_coords={"experimentVersionNumber": "time"})
+    assert "experimentVersionNumber" in res.variables
+    assert res.variables["experimentVersionNumber"].dimensions == ("time",)
+
+
 def test_OnDiskArray():
     res = dataset.open_file(TEST_DATA).variables["t"]
 


### PR DESCRIPTION
Currently, it is possible to define in `dataset.open_file` interface additional _attributes_ to be read, but not additional _coordinates_. 
With this PR we add the possibility to select extra _coordinates_ to be read.

This feature has been required by the CDS team for the new `grib_to_netcdf`,  to allow reading `experimentVersionNumber`  as a coordinate depending on time using Xarray. This is an example using the sample data in cfgrib tests directory:

``` python
>>> test_data = "tests/sample-data/era5-levels-members.grib"
>>> xr.open_dataset(test_data, engine="cfgrib", backend_kwargs={"extra_coords":{"experimentVersionNumber": "time"}}

<xarray.Dataset>
Dimensions:                  (isobaricInhPa: 2, latitude: 61, longitude: 120, number: 10, time: 4)
Coordinates:
  * number                   (number) int64 0 1 2 3 4 5 6 7 8 9
  * time                     (time) datetime64[ns] 2017-01-01 ... 2017-01-02T...
    step                     timedelta64[ns] ...
  * isobaricInhPa            (isobaricInhPa) int64 850 500
  * latitude                 (latitude) float64 90.0 87.0 84.0 ... -87.0 -90.0
  * longitude                (longitude) float64 0.0 3.0 6.0 ... 354.0 357.0
    valid_time               (time) datetime64[ns] ...
    experimentVersionNumber  (time) <U4 ...
Data variables:
    z                        (number, time, isobaricInhPa, latitude, longitude) float32 ...
    t                        (number, time, isobaricInhPa, latitude, longitude) float32 ...
```

- Add keyword `extra_coords` in `dataset.open_file`: supported only coordinates indexed by one dimension.
- Add tests.

