### PR TITLE
Add a GitHub action to test minimal version of dependencies

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -17,6 +17,9 @@ jobs:
           - os: ubuntu
             python: 3.9
             extras: -minimal
+          - os: ubuntu
+            python: 3.6
+            extras: -minver
 # python-eccodes fail on windows
 #          - os: windows
 #            python: 3.8

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -23,6 +23,9 @@ jobs:
           - os: ubuntu
             python: 3.9
             extras: -minimal
+          - os: ubuntu
+            python: 3.6
+            extras: -minver
 
     steps:
     - uses: actions/checkout@v2

--- a/environment-minimal.in.yml
+++ b/environment-minimal.in.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - attrs>=19.2
-  - cffi
   - click
   - numpy
   - python-eccodes>=2020.10.0

--- a/environment-minver.in.yml
+++ b/environment-minver.in.yml
@@ -1,0 +1,11 @@
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - attrs=19.2.0
+  - click=7.0.0
+  - eccodes=2.16.0
+  - numpy=1.15.0
+  - pandas=0.25.0
+  - python-eccodes=2020.06.0
+  - xarray=0.15.0

--- a/environment.in.yml
+++ b/environment.in.yml
@@ -9,4 +9,4 @@ dependencies:
   - pandas=1.0.5
   - python-eccodes>=2020.10.0
   - scipy
-  - xarray>=0.12.0
+  - xarray>=0.15.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     url="https://github.com/ecmwf/cfgrib",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=["attrs>=19.2", "click", "eccodes", "numpy"],
+    install_requires=["attrs>=19.2", "click", "eccodes>=0.9.8", "numpy"],
     python_requires=">=3.6",
     extras_require={
         "xarray": ["xarray>=0.15"],

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,9 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=["attrs>=19.2", "click", "eccodes", "numpy"],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     extras_require={
-        "xarray": ["xarray>=0.12.0"],
+        "xarray": ["xarray>=0.15.0"],
         "tests": ["dask[array]", "flake8", "pytest", "pytest-cov", "scipy", "xarray>=0.12.0",],
     },
     zip_safe=True,

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setuptools.setup(
     install_requires=["attrs>=19.2", "click", "eccodes", "numpy"],
     python_requires=">=3.6",
     extras_require={
-        "xarray": ["xarray>=0.15.0"],
-        "tests": ["dask[array]", "flake8", "pytest", "pytest-cov", "scipy", "xarray>=0.12.0",],
+        "xarray": ["xarray>=0.15"],
+        "tests": ["dask[array]", "flake8", "pytest", "pytest-cov", "scipy", "xarray>=0.15",],
     },
     zip_safe=True,
     keywords="eccodes grib xarray",

--- a/tests/environment-ubuntu-3.6-minver.yml
+++ b/tests/environment-ubuntu-3.6-minver.yml
@@ -1,14 +1,59 @@
-name: ubuntu-3.6-old
+name: ubuntu-3.6-minver
 channels:
   - defaults
   - conda-forge
 dependencies:
+  - _libgcc_mutex=0.1
   - attrs=19.2.0
+  - blas=1.0
+  - bzip2=1.0.8
+  - ca-certificates=2021.4.13
+  - certifi=2020.12.5
+  - cffi=1.14.5
   - click=7.0
+  - curl=7.71.1
   - eccodes=2.16.0
+  - hdf4=4.2.13
+  - hdf5=1.10.5
+  - intel-openmp=2019.4
+  - jasper=1.900.1
+  - jpeg=9d
+  - krb5=1.18.2
+  - ld_impl_linux-64=2.33.1
+  - libaec=1.0.4
+  - libcurl=7.71.1
+  - libedit=3.1.20210216
+  - libffi=3.3
+  - libgcc-ng=9.1.0
+  - libgfortran-ng=7.3.0
+  - libnetcdf=4.7.3
+  - libpng=1.6.37
+  - libssh2=1.9.0
+  - libstdcxx-ng=9.1.0
+  - mkl=2018.0.3
+  - mkl_fft=1.0.6
+  - mkl_random=1.0.1
+  - ncurses=6.2
   - numpy=1.15.0
+  - numpy-base=1.15.0
+  - openssl=1.1.1k
   - pandas=0.25.0
-  - pytest
+  - pip=21.0.1
+  - pycparser=2.20
   - python=3.6.13
+  - python-dateutil=2.8.1
   - python-eccodes=2020.06.0
+  - python_abi=3.6
+  - pytz=2021.1
+  - readline=8.1
+  - setuptools=52.0.0
+  - six=1.15.0
+  - sqlite=3.35.4
+  - tbb=2020.3
+  - tbb4py=2020.3
+  - tk=8.6.10
+  - wheel=0.36.2
   - xarray=0.15.0
+  - xz=5.2.5
+  - zlib=1.2.11
+prefix: /usr/share/miniconda/envs/ubuntu-3.6-minver

--- a/tests/environment-ubuntu-3.6-minver.yml
+++ b/tests/environment-ubuntu-3.6-minver.yml
@@ -1,0 +1,14 @@
+name: ubuntu-3.6-old
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - attrs=19.2.0
+  - click=7.0
+  - eccodes=2.16.0
+  - numpy=1.15.0
+  - pandas=0.25.0
+  - pytest
+  - python=3.6.13
+  - python-eccodes=2020.06.0
+  - xarray=0.15.0


### PR DESCRIPTION
Prompted by #227. See also https://github.com/conda-forge/cfgrib-feedstock/pull/22.

Versions of dependencies prior to the one listed break *cfgrib* one way or another.