### PR TITLE
Remove "edition" from GLOBAL_ATTRIBUTES_KEYS

### DIFF
--- a/cfgrib/dataset.py
+++ b/cfgrib/dataset.py
@@ -35,7 +35,7 @@ LOG = logging.getLogger(__name__)
 # Edition-independent keys in ecCodes namespaces. Documented in:
 #   https://software.ecmwf.int/wiki/display/ECC/GRIB%3A+Namespaces
 #
-GLOBAL_ATTRIBUTES_KEYS = ["edition", "centre", "centreDescription", "subCentre"]
+GLOBAL_ATTRIBUTES_KEYS = ["centre", "centreDescription", "subCentre"]
 
 DATA_ATTRIBUTES_KEYS = [
     "paramId",

--- a/tests/test_20_messages.py
+++ b/tests/test_20_messages.py
@@ -61,8 +61,6 @@ def test_Message_write(tmpdir):
     # warn on errors
     res["centreDescription"] = "DUMMY"
     assert res["centreDescription"] != "DUMMY"
-    res["edition"] = -1
-    assert res["edition"] != -1
 
     # ignore errors
     res.errors = "ignore"

--- a/tests/test_30_dataset.py
+++ b/tests/test_30_dataset.py
@@ -126,7 +126,6 @@ def test_Dataset():
     assert "Conventions" in res.attributes
     assert "institution" in res.attributes
     assert "history" in res.attributes
-    assert res.attributes["GRIB_edition"] == 1
     assert tuple(res.dimensions.keys()) == (
         "number",
         "time",
@@ -146,7 +145,6 @@ def test_Dataset_no_encode():
     assert "Conventions" in res.attributes
     assert "institution" in res.attributes
     assert "history" in res.attributes
-    assert res.attributes["GRIB_edition"] == 1
     assert tuple(res.dimensions.keys()) == ("number", "dataDate", "dataTime", "level", "values")
     assert len(res.variables) == 9
 
@@ -154,7 +152,6 @@ def test_Dataset_no_encode():
 def test_Dataset_encode_cf_time():
     res = dataset.open_file(TEST_DATA, encode_cf=("time",))
     assert "history" in res.attributes
-    assert res.attributes["GRIB_edition"] == 1
     assert tuple(res.dimensions.keys()) == ("number", "time", "level", "values")
     assert len(res.variables) == 9
 
@@ -165,7 +162,6 @@ def test_Dataset_encode_cf_time():
 def test_Dataset_encode_cf_geography():
     res = dataset.open_file(TEST_DATA, encode_cf=("geography",))
     assert "history" in res.attributes
-    assert res.attributes["GRIB_edition"] == 1
     assert tuple(res.dimensions.keys()) == (
         "number",
         "dataDate",
@@ -183,7 +179,6 @@ def test_Dataset_encode_cf_geography():
 def test_Dataset_encode_cf_vertical():
     res = dataset.open_file(TEST_DATA, encode_cf=("vertical",))
     assert "history" in res.attributes
-    assert res.attributes["GRIB_edition"] == 1
     expected_dimensions = ("number", "dataDate", "dataTime", "isobaricInhPa", "values")
     assert tuple(res.dimensions.keys()) == expected_dimensions
     assert len(res.variables) == 9

--- a/tests/test_40_xarray_store.py
+++ b/tests/test_40_xarray_store.py
@@ -16,6 +16,9 @@ TEST_IGNORE = os.path.join(SAMPLE_DATA_FOLDER, "uv_on_different_levels.grib")
 def test_open_dataset():
     res = xarray_store.open_dataset(TEST_DATA)
 
+    print(res.attrs)
+    assert res.attrs["GRIB_centre"] == "ecmf"
+
     var = res["t"]
     assert var.attrs["GRIB_gridType"] == "regular_ll"
     assert var.attrs["units"] == "K"
@@ -39,6 +42,7 @@ def test_open_dataset():
 def test_open_dataset_corrupted():
     res = xarray_store.open_dataset(TEST_CORRUPTED)
 
+    assert res.attrs["GRIB_centre"] == "ecmf"
     assert len(res.data_vars) == 1
 
     with pytest.raises(Exception):
@@ -49,6 +53,7 @@ def test_open_dataset_encode_cf_time():
     backend_kwargs = {"encode_cf": ("time",)}
     res = xarray_store.open_dataset(TEST_DATA, backend_kwargs=backend_kwargs)
 
+    assert res.attrs["GRIB_centre"] == "ecmf"
     assert res["t"].attrs["GRIB_gridType"] == "regular_ll"
     assert res["t"].attrs["GRIB_units"] == "K"
     assert res["t"].dims == ("number", "time", "level", "values")
@@ -70,6 +75,8 @@ def test_open_dataset_encode_cf_geography():
     backend_kwargs = {"encode_cf": ("geography",)}
     res = xarray_store.open_dataset(TEST_DATA, backend_kwargs=backend_kwargs)
 
+    assert res.attrs["GRIB_centre"] == "ecmf"
+
     var = res["t"]
     assert var.attrs["GRIB_gridType"] == "regular_ll"
     assert var.attrs["GRIB_units"] == "K"
@@ -80,6 +87,8 @@ def test_open_dataset_encode_cf_geography():
 
 def test_open_dataset_eccodes():
     res = xarray_store.open_dataset(TEST_DATA)
+
+    assert res.attrs["GRIB_centre"] == "ecmf"
 
     var = res["t"]
     assert var.attrs["GRIB_gridType"] == "regular_ll"

--- a/tests/test_40_xarray_store.py
+++ b/tests/test_40_xarray_store.py
@@ -16,8 +16,6 @@ TEST_IGNORE = os.path.join(SAMPLE_DATA_FOLDER, "uv_on_different_levels.grib")
 def test_open_dataset():
     res = xarray_store.open_dataset(TEST_DATA)
 
-    assert res.attrs["GRIB_edition"] == 1
-
     var = res["t"]
     assert var.attrs["GRIB_gridType"] == "regular_ll"
     assert var.attrs["units"] == "K"
@@ -41,7 +39,6 @@ def test_open_dataset():
 def test_open_dataset_corrupted():
     res = xarray_store.open_dataset(TEST_CORRUPTED)
 
-    assert res.attrs["GRIB_edition"] == 1
     assert len(res.data_vars) == 1
 
     with pytest.raises(Exception):
@@ -52,7 +49,6 @@ def test_open_dataset_encode_cf_time():
     backend_kwargs = {"encode_cf": ("time",)}
     res = xarray_store.open_dataset(TEST_DATA, backend_kwargs=backend_kwargs)
 
-    assert res.attrs["GRIB_edition"] == 1
     assert res["t"].attrs["GRIB_gridType"] == "regular_ll"
     assert res["t"].attrs["GRIB_units"] == "K"
     assert res["t"].dims == ("number", "time", "level", "values")
@@ -74,8 +70,6 @@ def test_open_dataset_encode_cf_geography():
     backend_kwargs = {"encode_cf": ("geography",)}
     res = xarray_store.open_dataset(TEST_DATA, backend_kwargs=backend_kwargs)
 
-    assert res.attrs["GRIB_edition"] == 1
-
     var = res["t"]
     assert var.attrs["GRIB_gridType"] == "regular_ll"
     assert var.attrs["GRIB_units"] == "K"
@@ -86,8 +80,6 @@ def test_open_dataset_encode_cf_geography():
 
 def test_open_dataset_eccodes():
     res = xarray_store.open_dataset(TEST_DATA)
-
-    assert res.attrs["GRIB_edition"] == 1
 
     var = res["t"]
     assert var.attrs["GRIB_gridType"] == "regular_ll"


### PR DESCRIPTION
As identified in issue https://github.com/ecmwf/cfgrib/issues/232, the GRIB edition should not be an global attribute key.

This is a duplicate of https://github.com/ecmwf/cfgrib/pull/233, because more changes are necessary to not have tests fail.