### PR TITLE
Fix the mypy error in master by updating the click library

### DIFF
--- a/tests/environment-ubuntu-3.8.yml
+++ b/tests/environment-ubuntu-3.8.yml
@@ -10,7 +10,7 @@ dependencies:
   - ca-certificates=2021.1.19
   - certifi=2020.12.5
   - cffi=1.14.5
-  - click=7.1.2
+  - click=8.0.1
   - curl=7.71.1
   - eccodes=2.19.1
   - hdf4=4.2.13


### PR DESCRIPTION
This is the smallest fix for the current mypy error that crashed the Github Actions.

Newer version of Mypy consider an error when a decodator is not typed and `click` added typing in version 8.