### PR TITLE
Fix numpy warning

### DIFF
--- a/cfgrib/dataset.py
+++ b/cfgrib/dataset.py
@@ -521,7 +521,7 @@ def build_variable_components(
     extra_dims = tuple(extra_coords.values())
     for dim in header_dimensions + extra_dims:
         if np.isscalar(coord_vars[dim].data):
-            header_value_index[dim] = {np.asscalar(coord_vars[dim].data): 0}
+            header_value_index[dim] = {coord_vars[dim].data.item(): 0}
         else:
             header_value_index[dim] = {v: i for i, v in enumerate(coord_vars[dim].data.tolist())}
     for header_values, offset in index.offsets:


### PR DESCRIPTION
I have removed the `numpy` warning:

```
cfgrib/dataset.py:526: DeprecationWarning:  np.asscalar(a) is deprecated since NumPy v1.16,  use a.item() instead
```

 replacing as suggested `np.asscalar` with `item()`.