### PR TITLE
Feature/backend kwargs json to netcdf

### DIFF
--- a/cfgrib/__main__.py
+++ b/cfgrib/__main__.py
@@ -55,14 +55,14 @@ def selfcheck() -> None:
 @click.option(
     "--backend-kwargs-json", "-b", default=None,
     help=(
-        'path to JSON file containing the backend kwargs '
-        'used in xarray.open_dataset.'
+        'Backend kwargs used in xarray.open_dataset.'
+        'Can either be a JSON format string or '
+        'the path to JSON file'
     )
 )
 def to_netcdf(inpaths, outpath, cdm, engine, backend_kwargs_json):
     # type: (T.List[str], str, str, str, str) -> None
     import xarray as xr
-    print('test')
     # NOTE: noop if no input argument
     if len(inpaths) == 0:
         return
@@ -72,8 +72,13 @@ def to_netcdf(inpaths, outpath, cdm, engine, backend_kwargs_json):
 
     if backend_kwargs_json is not None:
         import json   # only import if used
-        with open(backend_kwargs_json, 'r') as f:
-            backend_kwargs = json.load(f)
+        try:
+            # Assume a json format string
+            backend_kwargs = json.loads(backend_kwargs_json)
+        except json.JSONDecodeError:
+            # Then a json file
+            with open(backend_kwargs_json, 'r') as f:
+                backend_kwargs_json = json.load(f)
     else:
         backend_kwargs = {}
 

--- a/cfgrib/__main__.py
+++ b/cfgrib/__main__.py
@@ -77,7 +77,7 @@ def to_netcdf(inpaths, outpath, cdm, engine, backend_kwargs_json):
         except json.JSONDecodeError:
             # Then a json file
             with open(backend_kwargs_json, "r") as f:
-                backend_kwargs_json = json.load(f)
+                backend_kwargs = json.load(f)
     else:
         backend_kwargs = {}
 

--- a/cfgrib/__main__.py
+++ b/cfgrib/__main__.py
@@ -60,6 +60,7 @@ def selfcheck() -> None:
 def to_netcdf(inpaths, outpath, cdm, engine, backend_kwargs_json):
     # type: (T.List[str], str, str, str, str) -> None
     import json
+
     import xarray as xr
 
     import cf2cdm

--- a/cfgrib/__main__.py
+++ b/cfgrib/__main__.py
@@ -59,7 +59,10 @@ def selfcheck() -> None:
 )
 def to_netcdf(inpaths, outpath, cdm, engine, backend_kwargs_json):
     # type: (T.List[str], str, str, str, str) -> None
+    import json
     import xarray as xr
+
+    import cf2cdm
 
     # NOTE: noop if no input argument
     if len(inpaths) == 0:
@@ -69,8 +72,6 @@ def to_netcdf(inpaths, outpath, cdm, engine, backend_kwargs_json):
         outpath = os.path.splitext(inpaths[0])[0] + ".nc"
 
     if backend_kwargs_json is not None:
-        import json  # only import if used
-
         try:
             # Assume a json format string
             backend_kwargs = json.loads(backend_kwargs_json)
@@ -92,8 +93,6 @@ def to_netcdf(inpaths, outpath, cdm, engine, backend_kwargs_json):
         )  # type: ignore
 
     if cdm:
-        import cf2cdm  # only import if used
-
         coord_model = getattr(cf2cdm, cdm)
         ds = cf2cdm.translate_coords(ds, coord_model=coord_model)
 

--- a/cfgrib/__main__.py
+++ b/cfgrib/__main__.py
@@ -42,7 +42,7 @@ def selfcheck() -> None:
 @click.argument("inpaths", nargs=-1)
 @click.option(
     "--outpath", "-o", default=None,
-    help="Filename of the netcdf filename."
+    help="Filename of the output netcdf file."
 )
 @click.option(
     "--cdm", "-c", default=None,
@@ -62,7 +62,7 @@ def selfcheck() -> None:
 def to_netcdf(inpaths, outpath, cdm, engine, backend_kwargs_json):
     # type: (T.List[str], str, str, str, str) -> None
     import xarray as xr
-
+    print('test')
     # NOTE: noop if no input argument
     if len(inpaths) == 0:
         return

--- a/tests/test_60_main_commands.py
+++ b/tests/test_60_main_commands.py
@@ -32,6 +32,19 @@ def test_cfgrib_cli_to_netcdf(tmpdir: py.path.local) -> None:
     assert res.exit_code == 0
     assert res.output == ""
 
+    backend_kwargs = '{"time_dims": ["time"]}'
+    res = runner.invoke(__main__.cfgrib_cli, ["to_netcdf", TEST_DATA, "-b", backend_kwargs])
+
+    assert res.exit_code == 0
+    assert res.output == ""
+
+    backend_kwargs_json = tmpdir.join("temp.json")
+    with open(backend_kwargs_json, 'w') as f: f.write(backend_kwargs)
+    res = runner.invoke(__main__.cfgrib_cli, ["to_netcdf", TEST_DATA, "-b", str(backend_kwargs_json)])
+
+    assert res.exit_code == 0
+    assert res.output == ""
+
 
 def test_cfgrib_cli_dump() -> None:
     runner = click.testing.CliRunner()

--- a/tests/test_60_main_commands.py
+++ b/tests/test_60_main_commands.py
@@ -39,8 +39,11 @@ def test_cfgrib_cli_to_netcdf(tmpdir: py.path.local) -> None:
     assert res.output == ""
 
     backend_kwargs_json = tmpdir.join("temp.json")
-    with open(backend_kwargs_json, 'w') as f: f.write(backend_kwargs)
-    res = runner.invoke(__main__.cfgrib_cli, ["to_netcdf", TEST_DATA, "-b", str(backend_kwargs_json)])
+    with open(backend_kwargs_json, "w") as f:
+        f.write(backend_kwargs)
+    res = runner.invoke(
+        __main__.cfgrib_cli, ["to_netcdf", TEST_DATA, "-b", str(backend_kwargs_json)]
+    )
 
     assert res.exit_code == 0
     assert res.output == ""


### PR DESCRIPTION
Allow backend kwargs to be provided in the to_netcdf executable, either via a json format string, or a path to a json file.
Fixes #286 