### PR TITLE
xarray.to_netcdf kwargs and tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@ Changelog for cfgrib
 0.9.10.2 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- added --netcdf_kwargs_json option to 'cfgrib to_netcdf'
+  See `#294 <https://github.com/ecmwf/cfgrib/pull/294/>`_.
 
 
 0.9.10.1 (2022-03-16)

--- a/tests/test_60_main_commands.py
+++ b/tests/test_60_main_commands.py
@@ -32,6 +32,10 @@ def test_cfgrib_cli_to_netcdf(tmpdir: py.path.local) -> None:
     assert res.exit_code == 0
     assert res.output == ""
 
+
+def test_cfgrib_cli_to_netcdf_backend_kwargs(tmpdir: py.path.local) -> None:
+    runner = click.testing.CliRunner()
+
     backend_kwargs = '{"time_dims": ["time"]}'
     res = runner.invoke(__main__.cfgrib_cli, ["to_netcdf", TEST_DATA, "-b", backend_kwargs])
 
@@ -43,6 +47,26 @@ def test_cfgrib_cli_to_netcdf(tmpdir: py.path.local) -> None:
         f.write(backend_kwargs)
     res = runner.invoke(
         __main__.cfgrib_cli, ["to_netcdf", TEST_DATA, "-b", str(backend_kwargs_json)]
+    )
+
+    assert res.exit_code == 0
+    assert res.output == ""
+
+
+def test_cfgrib_cli_to_netcdf_netcdf_kwargs(tmpdir: py.path.local) -> None:
+    runner = click.testing.CliRunner()
+
+    netcdf_kwargs = '{"engine": "scipy"}'
+    res = runner.invoke(__main__.cfgrib_cli, ["to_netcdf", TEST_DATA, "-n", netcdf_kwargs])
+
+    assert res.exit_code == 0
+    assert res.output == ""
+
+    netcdf_kwargs_json = tmpdir.join("temp.json")
+    with open(netcdf_kwargs_json, "w") as f:
+        f.write(netcdf_kwargs)
+    res = runner.invoke(
+        __main__.cfgrib_cli, ["to_netcdf", TEST_DATA, "-n", str(netcdf_kwargs_json)]
     )
 
     assert res.exit_code == 0


### PR DESCRIPTION
Functionality to allow providing kwargs to xarray.to_netcdf in the `cfgrib to_netcdf` executable.
For example to use alternate engines or additional compression options.
The new calling syntax is:
cfgrib to_netcdf INFILE OUTFILE --netcdf_kwargs_json TO_XARRAY_KWARGS_JSON