### PR TITLE
Replace distutils.version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for cfgrib
 ====================
 
+0.9.10.3 (2022-xx-xx)
+---------------------
+
+- Replaced ``distutils.version`` py ``packaging.version`` and
+  added description and url to the xarray plugin.
+  See `#318 <https://github.com/ecmwf/cfgrib/pull/318/>`_.
+
+
 0.9.10.2 (2022-10-04)
 ---------------------
 

--- a/cfgrib/xarray_plugin.py
+++ b/cfgrib/xarray_plugin.py
@@ -73,6 +73,9 @@ class CfGribDataStore(AbstractDataStore):
 
 
 class CfGribBackend(BackendEntrypoint):
+    description = "Open GRIB files (.grib, .grib2, .grb and .grb2) in Xarray"
+    url = "https://github.com/ecmwf/cfgrib"
+
     def guess_can_open(
         self,
         store_spec: str,

--- a/cfgrib/xarray_plugin.py
+++ b/cfgrib/xarray_plugin.py
@@ -1,17 +1,18 @@
 import os
 import pathlib
 import typing as T
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 import xarray as xr
 
-from . import abc, dataset, messages
-
-if LooseVersion(xr.__version__) <= "0.17.0":
+if Version(xr.__version__) <= Version("0.17.0"):
     raise ImportError("xarray_plugin module needs xarray version >= 0.18+")
 
 from xarray.backends.common import AbstractDataStore, BackendArray, BackendEntrypoint
+
+if T.TYPE_CHECKING:
+    from . import abc, dataset, messages
 
 # FIXME: Add a dedicated lock, even if ecCodes is supposed to be thread-safe
 #   in most circumstances. See:
@@ -30,6 +31,7 @@ class CfGribDataStore(AbstractDataStore):
         lock: T.Union[T.ContextManager[T.Any], None] = None,
         **backend_kwargs: T.Any,
     ):
+        from . import dataset
         if lock is None:
             lock = ECCODES_LOCK
         self.lock = xr.backends.locks.ensure_lock(lock)  # type: ignore

--- a/cfgrib/xarray_plugin.py
+++ b/cfgrib/xarray_plugin.py
@@ -32,6 +32,7 @@ class CfGribDataStore(AbstractDataStore):
         **backend_kwargs: T.Any,
     ):
         from . import dataset
+
         if lock is None:
             lock = ECCODES_LOCK
         self.lock = xr.backends.locks.ensure_lock(lock)  # type: ignore

--- a/cfgrib/xarray_plugin.py
+++ b/cfgrib/xarray_plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 import typing as T
@@ -11,8 +13,7 @@ if Version(xr.__version__) <= Version("0.17.0"):
 
 from xarray.backends.common import AbstractDataStore, BackendArray, BackendEntrypoint
 
-if T.TYPE_CHECKING:
-    from . import abc, dataset, messages
+from . import abc, dataset, messages
 
 # FIXME: Add a dedicated lock, even if ecCodes is supposed to be thread-safe
 #   in most circumstances. See:
@@ -31,8 +32,6 @@ class CfGribDataStore(AbstractDataStore):
         lock: T.Union[T.ContextManager[T.Any], None] = None,
         **backend_kwargs: T.Any,
     ):
-        from . import dataset
-
         if lock is None:
             lock = ECCODES_LOCK
         self.lock = xr.backends.locks.ensure_lock(lock)  # type: ignore

--- a/cfgrib/xarray_plugin.py
+++ b/cfgrib/xarray_plugin.py
@@ -1,12 +1,10 @@
-from __future__ import annotations
-
 import os
 import pathlib
 import typing as T
-from packaging.version import Version
 
 import numpy as np
 import xarray as xr
+from packaging.version import Version
 
 if Version(xr.__version__) <= Version("0.17.0"):
     raise ImportError("xarray_plugin module needs xarray version >= 0.18+")


### PR DESCRIPTION
This PR replaces `distutils.version` by `packaging.version` to silence the DeprecationWarning in the xarray plugin.

Closes #312

Also, I have added the new description and url attributes (someone might want to check these).