### PR TITLE
Reducing memory leak related to accessing GRIB keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,14 @@ venv.bak/
 # mypy
 .mypy_cache/
 
+# editors
+.vscode
+
 # local ignores
 tests/sample-data/cds*.grib
 tests/sample-data/cds*.nc
 *.idx
+_dev
+
+# mac
+.DS_Store

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog for cfgrib
 0.9.10.3 (2022-xx-xx)
 ---------------------
 
+- large reduction in memory leak
+  See `#294 <https://github.com/ecmwf/cfgrib/pull/320/>`_.
+
 - Replaced ``distutils.version`` py ``packaging.version`` and
   added description and url to the xarray plugin.
   See `#318 <https://github.com/ecmwf/cfgrib/pull/318/>`_.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog for cfgrib
 ---------------------
 
 - large reduction in memory leak
-  See `#294 <https://github.com/ecmwf/cfgrib/pull/320/>`_.
+  See `#320 <https://github.com/ecmwf/cfgrib/pull/320/>`_.
 
 - Replaced ``distutils.version`` py ``packaging.version`` and
   added description and url to the xarray plugin.

--- a/cfgrib/messages.py
+++ b/cfgrib/messages.py
@@ -127,20 +127,18 @@ class Message(abc.MutableField):
         # type: (str, T.Optional[type], T.Any) -> T.Any
         """Get value of a given key as its native or specified type."""
         try:
-            is_array = eccodes.codes_get_size(self.codes_id, item) > 1
-            if is_array:
+            if eccodes.codes_get_size(self.codes_id, item) > 1:
                 values = eccodes.codes_get_array(self.codes_id, item, key_type)
             else:
-                values = eccodes.codes_get(self.codes_id, item, key_type)
+                values = [eccodes.codes_get(self.codes_id, item, key_type)]
 
             if values is None:
                 return "unsupported_key_type"
 
-            if is_array and len(values) == 1:
+            if len(values) == 1:
                 if isinstance(values, np.ndarray):
                     values = values.tolist()
                 return values[0]
-
             return values
 
         except eccodes.KeyValueNotFoundError:

--- a/cfgrib/messages.py
+++ b/cfgrib/messages.py
@@ -127,19 +127,27 @@ class Message(abc.MutableField):
         # type: (str, T.Optional[type], T.Any) -> T.Any
         """Get value of a given key as its native or specified type."""
         try:
-            values = eccodes.codes_get_array(self.codes_id, item, key_type)
+            is_array = eccodes.codes_get_size(self.codes_id, item) > 1
+            if is_array:
+                values = eccodes.codes_get_array(self.codes_id, item, key_type)
+            else:
+                values = eccodes.codes_get(self.codes_id, item, key_type)
+
             if values is None:
-                values = ["unsupported_key_type"]
+                return "unsupported_key_type"
+
+            if is_array and len(values) == 1:
+                if isinstance(values, np.ndarray):
+                    values = values.tolist()
+                return values[0]
+
+            return values
+
         except eccodes.KeyValueNotFoundError:
             if default is _MARKER:
                 raise KeyError(item)
             else:
                 return default
-        if len(values) == 1:
-            if isinstance(values, np.ndarray):
-                values = values.tolist()
-            return values[0]
-        return values
 
     def message_set(self, item: str, value: T.Any) -> None:
         arr = isinstance(value, (np.ndarray, T.Sequence)) and not isinstance(value, str)


### PR DESCRIPTION
Helps reducing the memory leak reported in #283. 

The problem was related to the way cfgrib accessed ecCodes keys. It used 

`eccodes.codes_get_array()`

exclusively.  However, this seems to have caused a memory leak (inside ecCodes), especially when accessing string keys (e.g. "shortName"). By avoiding using eccodes.codes_get_array() for non-array keys the memory leak reduced significantly, although it is still present.

A comparison:

Using a GRIB file containing 420 messages, if we execute the following function 500 times:

```
def run():
    ds = xr.open_dataset(fname, engine="cfgrib", backend_kwargs={"indexpath": ""})
    total = len(ds)
    ds = None
```

the final RSS memory usage with the original code is 1334 MB, while with the fix it is only 96 MB.