### PR TITLE
variable encoding for to_netcdf

### DIFF
--- a/cfgrib/__main__.py
+++ b/cfgrib/__main__.py
@@ -78,13 +78,22 @@ def selfcheck() -> None:
     "-n",
     default=None,
     help=(
-        "kwargs used xarray.to_netcdf when creating the netCDF file."
-        "Can either be a JSON format string or "
-        "the path to JSON file."
+        "kwargs used xarray.to_netcdf when creating the netCDF file. "
+        "Can either be a JSON format string or the path to JSON file. "
     ),
 )
-def to_netcdf(inpaths, outpath, cdm, engine, backend_kwargs_json, netcdf_kwargs_json):
-    # type: (T.List[str], str, str, str, str, str) -> None
+@click.option(
+    "--var-encoding-json",
+    "-v",
+    default=None,
+    help=(
+        "encoding options to apply to all data variables in the dataset. "
+        "Can either be a JSON format string or the path to JSON file. "
+    ),
+)
+def to_netcdf(
+    inpaths, outpath, cdm, engine, backend_kwargs_json, netcdf_kwargs_json, var_encoding_json
+):  # type: (T.List[str], str, str, str, str, str, str) -> None
     import xarray as xr
 
     import cf2cdm
@@ -124,6 +133,12 @@ def to_netcdf(inpaths, outpath, cdm, engine, backend_kwargs_json, netcdf_kwargs_
         netcdf_kwargs = handle_json(netcdf_kwargs_json)
     else:
         netcdf_kwargs = {}
+
+    if var_encoding_json is not None:
+        var_encoding = handle_json(var_encoding_json)
+        netcdf_kwargs.setdefault("encoding", {})
+        for var in ds.data_vars:
+            netcdf_kwargs["encoding"].setdefault(var, var_encoding)
 
     ds.to_netcdf(outpath, **netcdf_kwargs)
 

--- a/cfgrib/xarray_plugin.py
+++ b/cfgrib/xarray_plugin.py
@@ -105,7 +105,6 @@ class CfGribBackend(BackendEntrypoint):
         errors: str = "warn",
         extra_coords: T.Dict[str, str] = {},
     ) -> xr.Dataset:
-
         store = CfGribDataStore(
             filename_or_obj,
             indexpath=indexpath,

--- a/tests/test_60_main_commands.py
+++ b/tests/test_60_main_commands.py
@@ -73,6 +73,26 @@ def test_cfgrib_cli_to_netcdf_netcdf_kwargs(tmpdir: py.path.local) -> None:
     assert res.output == ""
 
 
+def test_cfgrib_cli_to_netcdf_var_encoding(tmpdir: py.path.local) -> None:
+    runner = click.testing.CliRunner()
+
+    var_encoding = '{"dtype": "float", "scale_factor": 0.1}'
+    res = runner.invoke(__main__.cfgrib_cli, ["to_netcdf", TEST_DATA, "-v", var_encoding])
+
+    assert res.exit_code == 0
+    assert res.output == ""
+
+    var_encoding_json = tmpdir.join("temp.json")
+    with open(var_encoding_json, "w") as f:
+        f.write(var_encoding)
+    res = runner.invoke(
+        __main__.cfgrib_cli, ["to_netcdf", TEST_DATA, "-v", str(var_encoding_json)]
+    )
+
+    assert res.exit_code == 0
+    assert res.output == ""
+
+
 def test_cfgrib_cli_dump() -> None:
     runner = click.testing.CliRunner()
 


### PR DESCRIPTION
This is required because netCDF encoding options (e.g. compression options) need to be added per variable and it is not always possible/simple/sensible to know what variables are in the grib file before converting to netCDF.

This change allows users to provide a common set of compression options which are applied to each data variable in the xr.dataset. Any encoding provided in the netcdf_kwargs_json overrides what is set via the global var_encoding_json.

The variable encoding is parsed using the -v or --var-encoding-json options, e.g.:
cfgrib to_netcdf -v '{"dtype": "float", "scale_factor": 0.1}' -o $OUTFILE $INFILE
