### PR TITLE
Feature: File name in the indexpath

### DIFF
--- a/cfgrib/messages.py
+++ b/cfgrib/messages.py
@@ -529,7 +529,8 @@ class FileIndex(FieldsetIndex):
             return cls.from_fieldset(filestream, index_keys, computed_keys)
 
         hash = hashlib.md5(repr(index_keys).encode("utf-8")).hexdigest()
-        indexpath = indexpath.format(path=filestream.path, hash=hash, short_hash=hash[:5])
+        indexpath = indexpath.format(path=filestream.path, file_name=os.path.basename(filestream.path), hash=hash, short_hash=hash[:5])
+
         try:
             with compat_create_exclusive(indexpath) as new_index_file:
                 self = cls.from_fieldset(filestream, index_keys, computed_keys)

--- a/tests/test_20_messages.py
+++ b/tests/test_20_messages.py
@@ -179,6 +179,13 @@ def test_FileIndex_from_indexpath_or_filestream(tmpdir: py.path.local) -> None:
     )
     assert isinstance(res, messages.FileIndex)
 
+    # setting the indexpath manually (with file_name variable)
+    res = messages.FileIndex.from_indexpath_or_filestream(
+        messages.FileStream(str(grib_file)), ["paramId"], 
+        indexpath=str(tmpdir) + '{file_name}.idx.{short_hash}'
+    )
+    assert isinstance(res, messages.FileIndex)
+
     # can't create nor read index file
     res = messages.FileIndex.from_indexpath_or_filestream(
         messages.FileStream(str(grib_file)),


### PR DESCRIPTION
This is a small contribution that solves a problem I was having with `xarray.open_mfdataset`. In my setup, I don't have write access to the directories where the grib files are, so cfgrib fails to write the index files. After digging around for a bit, I found the `indexpath` argument, but I didn't see a way to have `xarray.open_mfdataset` save a separate index file for each file opened. So this fixes that by adding a `file_name` variable to the format on the `indexpath` argument. Now, the user can open multiple files by calling

```python
ds = xr.open_mfdataset("/path/to/files*.grib", 
                       backend_kwargs={'indexpath': '/path/to/indexes/{file_name}.idx.{short_hash}'})
```

and the index files for each file read get saved in the alternate path.