### PR TITLE
Feature/index create dir

### DIFF
--- a/cfgrib/messages.py
+++ b/cfgrib/messages.py
@@ -23,6 +23,7 @@ import logging
 import os
 import pickle
 import typing as T
+from pathlib import Path
 
 import attr
 import eccodes  # type: ignore
@@ -530,6 +531,12 @@ class FileIndex(FieldsetIndex):
 
         hash = hashlib.md5(repr(index_keys).encode("utf-8")).hexdigest()
         indexpath = indexpath.format(path=filestream.path, hash=hash, short_hash=hash[:5])
+
+        if not Path(indexpath).parent.exists():
+            # When reading from read-only partition, we can define indexes in another
+            # directory, eg. indexpath='/tmp/indexes/{path}.idx'
+            Path(indexpath).parent.mkdir(parents=True, exist_ok=True)
+
         try:
             with compat_create_exclusive(indexpath) as new_index_file:
                 self = cls.from_fieldset(filestream, index_keys, computed_keys)

--- a/tests/test_20_messages.py
+++ b/tests/test_20_messages.py
@@ -197,6 +197,15 @@ def test_FileIndex_from_indexpath_or_filestream(tmpdir: py.path.local) -> None:
     )
     assert isinstance(res, messages.FileIndex)
 
+    # trigger index dir creation
+    res = messages.FileIndex.from_indexpath_or_filestream(
+        messages.FileStream(str(grib_file)),
+        ["paramId"],
+        indexpath=str(tmpdir / "non-existent-folder" / "{path}.idx"),
+    )
+    assert isinstance(res, messages.FileIndex)
+    assert (tmpdir / "non-existent-folder").exists()
+
 
 def test_FileIndex_errors() -> None:
     computed_keys = {"error_key": (lambda m: bool(1 / 0), lambda m, v: None)}  # pragma: no branch


### PR DESCRIPTION
When working with many GRIB files on read-only partition, we set a lot of time ``indexpath=''`` to avoid error messages. However, it's very slow because we don't use indexes at all.

This simple PR will allow us to set a particular directory for index files, by automatically create path if needed.

Example of usage : 

```
ds = xr.open_dataset(fp, engine='cfgrib', backend_kwargs={'indexpath': '/tmp/indexes/{path}.idx'})
```