### PR TITLE
Preserve coordinate encoding in cfgrib.open_datasets

### DIFF
--- a/cfgrib/xarray_store.py
+++ b/cfgrib/xarray_store.py
@@ -57,15 +57,15 @@ def merge_datasets(datasets, **kwargs):
         else:
             merged.append(ds)
             first.append(ds)
-    
+
     # Add the important coordinate encoding fields from the first found, to the merged:
-    preserve_encoding_fields = [
-        'source', 'units', 'calendar', 'dtype'
-    ]
+    preserve_encoding_fields = ["source", "units", "calendar", "dtype"]
     for i, o in enumerate(first):
         for var in o.coords:
             out_encoding = {
-                key: o[var].encoding[key] for key in preserve_encoding_fields if key in o[var].encoding
+                key: o[var].encoding[key]
+                for key in preserve_encoding_fields
+                if key in o[var].encoding
             }
             merged[i][var].encoding.update(out_encoding)
 

--- a/cfgrib/xarray_store.py
+++ b/cfgrib/xarray_store.py
@@ -42,6 +42,7 @@ def open_dataset(path, **kwargs):
 def merge_datasets(datasets, **kwargs):
     # type: (T.Sequence[xr.Dataset], T.Any) -> T.List[xr.Dataset]
     merged = []  # type: T.List[xr.Dataset]
+    first = []  # type: T.List[xr.Dataset]
     for ds in datasets:
         ds.attrs.pop("history", None)
         for i, o in enumerate(merged):
@@ -55,6 +56,19 @@ def merge_datasets(datasets, **kwargs):
                     pass
         else:
             merged.append(ds)
+            first.append(ds)
+    
+    # Add the important coordinate encoding fields from the first found, to the merged:
+    preserve_encoding_fields = [
+        'source', 'units', 'calendar', 'dtype'
+    ]
+    for i, o in enumerate(first):
+        for var in o.coords:
+            out_encoding = {
+                key: o[var].encoding[key] for key in preserve_encoding_fields if key in o[var].encoding
+            }
+            merged[i][var].encoding.update(out_encoding)
+
     return merged
 
 

--- a/tests/test_40_xarray_store.py
+++ b/tests/test_40_xarray_store.py
@@ -171,6 +171,7 @@ def test_open_datasets_differet_preserve_coordinate_encoding() -> None:
     assert "units" in res[0].valid_time.encoding
     assert "units" in res[1].valid_time.encoding
 
+
 def test_open_dataset_steps_in_minutes() -> None:
     res = xarray_store.open_dataset(TEST_DATA_STEPS_IN_MINUTES)
 

--- a/tests/test_40_xarray_store.py
+++ b/tests/test_40_xarray_store.py
@@ -159,6 +159,18 @@ def test_open_datasets_differet_step_types_zeros() -> None:
     assert res[1].cfrzr.attrs["GRIB_stepType"] == "avg"
 
 
+# ensure that the encoding of the coordinates is preserved
+def test_open_datasets_differet_preserve_coordinate_encoding() -> None:
+    res = xarray_store.open_datasets(TEST_DATA_DIFFERENT_STEP_TYPES)
+    assert len(res) == 2
+    assert "units" in res[0].valid_time.encoding
+    assert "units" in res[1].valid_time.encoding
+
+    res = xarray_store.open_datasets(TEST_DATA_DIFFERENT_STEP_TYPES_ZEROS)
+    assert len(res) == 2
+    assert "units" in res[0].valid_time.encoding
+    assert "units" in res[1].valid_time.encoding
+
 def test_open_dataset_steps_in_minutes() -> None:
     res = xarray_store.open_dataset(TEST_DATA_STEPS_IN_MINUTES)
 


### PR DESCRIPTION
xr.merge drops the variable encoding (as well as the attributes), hence this information is often lost when using open_datasets. This information is particularly useful for time variables as the units ensure that the data is written correctly to a netCDF file. When units are not found for a time variable they are encoded in "nanoseconds since XXX", which is not compatible with some software (e.g. netcdf4.num2date).

The code change preserves the "important" pieces of encoding, that one can consider consistent for all fields, and a test is included to ensure that it works (without the code change the test fails)