### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -38,7 +38,7 @@ jobs:
         conda env export --no-build -f tests/environment-${{ matrix.os }}-${{ matrix.python }}${{ matrix.extras }}.yml
         git diff
     - name: Archive environment-${{ matrix.os }}-${{ matrix.python }}${{ matrix.extras }}.yml
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: environment-${{ matrix.os }}-${{ matrix.python }}${{ matrix.extras }}.yml
         path: tests/environment-${{ matrix.os }}-${{ matrix.python }}${{ matrix.extras }}.yml


### PR DESCRIPTION
Update upload-artifact and download-artifact actions to v4 as v3 and older are deprecated and will soon be removed. See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/