### PR TITLE
Add values_dtype backend option to load values at full precision

### DIFF
--- a/cfgrib/messages.py
+++ b/cfgrib/messages.py
@@ -69,6 +69,7 @@ KEY_TYPES = {
 }
 
 DEFAULT_INDEXPATH = "{path}.{short_hash}.idx"
+DEFAULT_VALUES_DTYPE = np.dtype("float32")
 
 OffsetType = T.Union[int, T.Tuple[int, int]]
 

--- a/cfgrib/xarray_plugin.py
+++ b/cfgrib/xarray_plugin.py
@@ -107,6 +107,7 @@ class CfGribBackend(BackendEntrypoint):
         extra_coords: T.Dict[str, str] = {},
         coords_as_attributes: T.Dict[str, str] = {},
         cache_geo_coords: bool = True,
+        values_dtype: np.dtype = messages.DEFAULT_VALUES_DTYPE,
     ) -> xr.Dataset:
         store = CfGribDataStore(
             filename_or_obj,
@@ -122,6 +123,7 @@ class CfGribBackend(BackendEntrypoint):
             extra_coords=extra_coords,
             coords_as_attributes=coords_as_attributes,
             cache_geo_coords=cache_geo_coords,
+            values_dtype=values_dtype,
         )
         with xr.core.utils.close_on_error(store):
             vars, attrs = store.load()  # type: ignore

--- a/tests/test_30_dataset.py
+++ b/tests/test_30_dataset.py
@@ -380,3 +380,17 @@ def test_missing_field_values() -> None:
     t2 = res.variables["t2m"]
     assert np.isclose(np.nanmean(t2.data[0, :, :]), 268.375)
     assert np.isclose(np.nanmean(t2.data[1, :, :]), 270.716)
+
+
+def test_default_values_dtype() -> None:
+    res = dataset.open_file(TEST_DATA_MISSING_VALS)
+    assert res.variables["t2m"].data.dtype == np.dtype("float32")
+    assert res.variables["latitude"].data.dtype == np.dtype("float64")
+    assert res.variables["longitude"].data.dtype == np.dtype("float64")
+
+
+def test_float64_values_dtype() -> None:
+    res = dataset.open_file(TEST_DATA_MISSING_VALS, values_dtype=np.dtype("float64"))
+    assert res.variables["t2m"].data.dtype == np.dtype("float64")
+    assert res.variables["latitude"].data.dtype == np.dtype("float64")
+    assert res.variables["longitude"].data.dtype == np.dtype("float64")

--- a/tests/test_50_xarray_plugin.py
+++ b/tests/test_50_xarray_plugin.py
@@ -176,3 +176,17 @@ def test_xr_open_dataset_coords_to_attributes() -> None:
 
     assert "GRIB_surface" in ds["t2m"].attrs
     assert "GRIB_depthBelowLandLayer" in ds["stl1"].attrs
+
+
+def test_xr_open_dataset_default_values_dtype() -> None:
+    ds = xr.open_dataset(TEST_DATA_MISSING_VALS, engine="cfgrib")
+    assert ds["t2m"].data.dtype == np.dtype("float32")
+    assert ds["latitude"].data.dtype == np.dtype("float64")
+    assert ds["longitude"].data.dtype == np.dtype("float64")
+
+
+def test_xr_open_dataset_float64_values_dtype() -> None:
+    ds = xr.open_dataset(TEST_DATA_MISSING_VALS, engine="cfgrib", values_dtype=np.dtype("float64"))
+    assert ds["t2m"].data.dtype == np.dtype("float64")
+    assert ds["latitude"].data.dtype == np.dtype("float64")
+    assert ds["longitude"].data.dtype == np.dtype("float64")


### PR DESCRIPTION
Supersedes #395

https://github.com/ecmwf/cfgrib/pull/395#issuecomment-2257793827
> Hi @juntyr and @dmey, thanks for this change! However, I think this is something we would prefer to be an option since it will double the memory requirement (and we do have GRIB fields with over 1 billion values).
> 
> Potential API:
> 
> ```
> ds = xr.open_dataset('data.grib', engine='cfgrib', backend_kwargs={'values_dtype': 'float64'})
> ```
> 
> Do you think you could make this modification to the PR, or would you rather leave it as a request issue?