### PR TITLE
Fix `xarray.backends` imports

### DIFF
--- a/cfgrib/xarray_plugin.py
+++ b/cfgrib/xarray_plugin.py
@@ -10,13 +10,14 @@ if Version(xr.__version__) <= Version("0.17.0"):
     raise ImportError("xarray_plugin module needs xarray version >= 0.18+")
 
 from xarray.backends.common import AbstractDataStore, BackendArray, BackendEntrypoint
+from xarray.backends.locks import SerializableLock, ensure_lock
 
 from . import abc, dataset, messages
 
 # FIXME: Add a dedicated lock, even if ecCodes is supposed to be thread-safe
 #   in most circumstances. See:
 #       https://confluence.ecmwf.int/display/ECC/Frequently+Asked+Questions
-ECCODES_LOCK = xr.backends.locks.SerializableLock()  # type: ignore
+ECCODES_LOCK = SerializableLock()  # type: ignore
 
 
 class CfGribDataStore(AbstractDataStore):
@@ -32,7 +33,7 @@ class CfGribDataStore(AbstractDataStore):
     ):
         if lock is None:
             lock = ECCODES_LOCK
-        self.lock = xr.backends.locks.ensure_lock(lock)  # type: ignore
+        self.lock = ensure_lock(lock)  # type: ignore
         if isinstance(filename, (str, pathlib.PurePath)):
             opener = dataset.open_file
         else:

--- a/cfgrib/xarray_to_grib.py
+++ b/cfgrib/xarray_to_grib.py
@@ -26,6 +26,7 @@ import warnings
 
 import numpy as np
 import xarray as xr
+from xarray.backends import api as backends_api
 
 from . import cfmessage, dataset, messages
 
@@ -252,12 +253,12 @@ def canonical_dataset_to_grib(dataset, path, mode="wb", no_warn=False, grib_keys
         warnings.warn("GRIB write support is experimental, DO NOT RELY ON IT!", FutureWarning)
 
     # validate Dataset keys, DataArray names, and attr keys/values
-    xr.backends.api._validate_dataset_names(dataset)  # type: ignore
+    backends_api._validate_dataset_names(dataset)  # type: ignore
     # _validate_attrs takes the engine name as its 2nd arg from xarray 2024.09.0
     try:
-        xr.backends.api._validate_attrs(dataset)  # type: ignore
+        backends_api._validate_attrs(dataset)  # type: ignore
     except TypeError:
-        xr.backends.api._validate_attrs(dataset, "cfgrib")  # type: ignore
+        backends_api._validate_attrs(dataset, "cfgrib")  # type: ignore
 
     real_grib_keys = {str(k)[5:]: v for k, v in dataset.attrs.items() if str(k)[:5] == "GRIB_"}
     real_grib_keys.update(grib_keys)


### PR DESCRIPTION
In the recent versions of `xarray`, it appears that `xarray.backends` is not a public subpackage, so accessing it through `import xarray as xr` followed by `xr.backends` now raises an `AttributeError`.

This PR fixes the handful of instances where this was occurring.