### PR TITLE
ENH: Add potentialVorticity coordinate metadata

### DIFF
--- a/cfgrib/dataset.py
+++ b/cfgrib/dataset.py
@@ -222,6 +222,12 @@ COORD_ATTRS = {
         "standard_name": "air_pressure",
         "long_name": "pressure",
     },
+    "potentialVorticity": {
+        "units": "K m^2 kg^-1 s^-1",
+        "standard_name": "ertel_potential_vorticity",
+        "units_metadata": "temperature: difference",
+        "long_name": "potential_vorticity",
+    }
     # ensemble
     "number": {
         "units": "1",


### PR DESCRIPTION
### Description

Add metadata for the potential vorticity vertical coordinate/typeOfLevel=potentialVorticity

Units copied from https://codes.ecmwf.int/grib/param-db/60 https://codes.ecmwf.int/grib/format/grib2/ctables/4/5/ agrees

NCEP has slightly different units for the GRIB2 vertical coordinate: https://www.nco.ncep.noaa.gov/pmb/docs/on388/table3.html

I had variables with typeOfLevel=potentialVorticity and noticed I couldn't convert the vertical coordinate to PVU

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 