### PR TITLE
MNT: Provide dtype attribute for step coordinate

### DIFF
--- a/cfgrib/dataset.py
+++ b/cfgrib/dataset.py
@@ -233,6 +233,7 @@ COORD_ATTRS = {
         "units": "hours",
         "standard_name": "forecast_period",
         "long_name": "time since forecast_reference_time",
+        "dtype": "timedelta64[s]",
     },
     "time": {
         "units": "seconds since 1970-01-01T00:00:00",


### PR DESCRIPTION
### Description

XArray is planning to stop auto-decoding variables with a time unit into timedelta dtypes, unless the variable has a timedelta dtype attribute (discussed at pydata/xarray#1621 and pydata/xarray#10099).

Seconds is the largest time unit XArray supports.  I think this supports timedeltas over 100 billion years, so I don't expect problems from that.

This quiets an XArray `FutureWarning`, and shouldn't do anything with older versions of XArray, though older versions only have `timedelta64[ns]`, so they can only handle time-deltas up to around 300 years, independent of this change (I think there's a `decode_timedelta=False` keyword argument that would avoid the auto-conversion

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 