### PR TITLE
Fix memory leak issue.

### DIFF
--- a/cfgrib/messages.py
+++ b/cfgrib/messages.py
@@ -98,8 +98,10 @@ class Message(abc.MutableField):
         else:
             # MULTI-FIELD is enabled only when accessing additional fields
             with multi_enabled(file):
-                for _ in range(field_in_message + 1):
+                for i in range(field_in_message + 1):
                     codes_id = eccodes.codes_grib_new_from_file(file)
+                    if codes_id is not None and i < field_in_message:
+                        eccodes.codes_release(codes_id)
 
         if codes_id is None:
             raise EOFError("End of file: %r" % file)


### PR DESCRIPTION
### Description
Call eccodes.codes_grib_new_from_file in loop but only use the last codes_id, other codes_ids are not released and missing. 
Need to merge https://github.com/ecmwf/eccodes/pull/352  as well to fix the bug.
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 