### PR TITLE
Change FileStream to use absolute paths

### DIFF
--- a/cfgrib/messages.py
+++ b/cfgrib/messages.py
@@ -322,7 +322,9 @@ class FileStream(abc.MappingFieldset[OffsetType, Message]):
     14760.0
     """
 
-    path: str
+    path: str = attr.field(
+        converter=os.path.abspath, eq=os.path.abspath, on_setattr=os.path.abspath
+    )
     errors: str = attr.attrib(
         default="warn", validator=attr.validators.in_(["ignore", "warn", "raise"])
     )


### PR DESCRIPTION
### Description

Currently, accessing a grib file first by a relative path then by an absolute path causes cfgrib to reject the index, as would acessing the file by a relative path from a different working directory.

This change ensures the path stored in the index file is absolute, so the index file validator will find a match regardless of whether the file is accessed by a relative path or an absolute path.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 