### PR TITLE
ENH: Add axis attribute to 1-D latitude and longitude coordinates

### DIFF
--- a/cfgrib/dataset.py
+++ b/cfgrib/dataset.py
@@ -414,6 +414,9 @@ def build_geography_coordinates(
             data=np.array(first["distinctLongitudes"], ndmin=1),
             attributes=COORD_ATTRS["longitude"],
         )
+        # latitude and longitude are dimension coordinates
+        geo_coord_vars["latitude"].attrs["axis"] = "Y"
+        geo_coord_vars["longitude"].attrs["axis"] = "X"
     elif "geography" in encode_cf and grid_type in GRID_TYPES_2D_NON_DIMENSION_COORDS:
         geo_dims = ("y", "x")
         geo_shape = (first["Ny"], first["Nx"])

--- a/cfgrib/dataset.py
+++ b/cfgrib/dataset.py
@@ -415,8 +415,8 @@ def build_geography_coordinates(
             attributes=COORD_ATTRS["longitude"],
         )
         # latitude and longitude are dimension coordinates
-        geo_coord_vars["latitude"].attrs["axis"] = "Y"
-        geo_coord_vars["longitude"].attrs["axis"] = "X"
+        geo_coord_vars["latitude"].attributes["axis"] = "Y"
+        geo_coord_vars["longitude"].attributes["axis"] = "X"
     elif "geography" in encode_cf and grid_type in GRID_TYPES_2D_NON_DIMENSION_COORDS:
         geo_dims = ("y", "x")
         geo_shape = (first["Ny"], first["Nx"])


### PR DESCRIPTION
### Description

Add the `axis` attribute to identify 1-D dimension coordinates already provided by cfgrib.
This attribute is recommended at the end of CF section 4:
https://cfconventions.org/Data/cf-conventions/cf-conventions-1.12/cf-conventions.html#coordinate-types

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 