### PR TITLE
Addresed FIPS compliance issues 

### DIFF
--- a/cfgrib/messages.py
+++ b/cfgrib/messages.py
@@ -531,8 +531,11 @@ class FileIndex(FieldsetIndex):
         # Reading and writing the index can be explicitly suppressed by passing indexpath==''.
         if not indexpath:
             return cls.from_fieldset(filestream, index_keys, computed_keys)
-
-        hash = hashlib.md5(repr(index_keys).encode("utf-8")).hexdigest()
+        repr_index_keys = repr(index_keys).encode("utf-8")
+        try:
+            hash = hashlib.md5(repr_index_keys, usedforsecurity=False).hexdigest()
+        except TypeError:
+            hash = hashlib.md5(repr_index_keys).hexdigest()
         indexpath = indexpath.format(path=filestream.path, hash=hash, short_hash=hash[:5])
         try:
             with compat_create_exclusive(indexpath) as new_index_file:


### PR DESCRIPTION
Due to FIPS(Federal information Processing Standards) newer versions of cfgrib encounter an error during runtime. This issue can be addressed by setting the usedforsecurity flag on hashlib md5 to false. Due to the primary use of this project being an API to support a grib engine for xarray this flag can be set to false.

The code change is based on an issue opened previously
https://github.com/ecmwf/cfgrib/issues/383
 